### PR TITLE
EIP2612PermitAndDeposit Functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@pooltogether/utilities": "^0.6.2",
     "@pooltogether/v4-utils-js": "0.1.5",
     "debug": "^4.3.3",
+    "eth-permit": "^0.2.3",
     "ethers": "^5.4.6"
   }
 }

--- a/src/PrizePool.ts
+++ b/src/PrizePool.ts
@@ -6,6 +6,7 @@ import { Contract } from '@ethersproject/contracts'
 import { Contract as ContractMetadata, ContractList } from '@pooltogether/contract-list-schema'
 
 import ERC20Abi from './abis/ERC20Abi'
+import ERC20AbiWithPermit from './abis/ERC20AbiWithPermit'
 import { ContractType } from './constants'
 import { PrizePoolTokenBalances, Providers, TokenData } from './types'
 import {
@@ -343,9 +344,10 @@ export class PrizePool {
 
   /**
    * Fetches the addresses to build an instance of an ethers Contract for the underlying Token
+   * @param options optional settings or toggles
    * @returns an ethers contract for the underlying token
    */
-  async getTokenContract(): Promise<Contract> {
+  async getTokenContract(options?: { eip2612?: boolean }): Promise<Contract> {
     if (this.tokenContract !== undefined) return this.tokenContract
     const getAddress = async () => {
       const result: Result = await this.prizePoolContract.functions.getToken()
@@ -356,7 +358,7 @@ export class PrizePool {
       this.chainId,
       tokenAddress,
       ContractType.Token,
-      ERC20Abi
+      options?.eip2612 ? ERC20AbiWithPermit : ERC20Abi
     )
     const tokenContract = new Contract(
       tokenMetadata.address,

--- a/src/PrizePool.ts
+++ b/src/PrizePool.ts
@@ -30,11 +30,13 @@ export class PrizePool {
 
   // Contract metadata
   readonly prizePoolMetadata: ContractMetadata
+  readonly eip2612PermitAndDepositMetadata: ContractMetadata | undefined
   ticketMetadata: ContractMetadata | undefined
   tokenMetadata: ContractMetadata | undefined
 
   // Ethers contracts
   readonly prizePoolContract: Contract
+  readonly eip2612PermitAndDepositContract: Contract | undefined
   ticketContract: Contract | undefined
   tokenContract: Contract | undefined
 
@@ -50,26 +52,37 @@ export class PrizePool {
     signerOrProvider: Provider | Signer,
     contractMetadataList: ContractMetadata[]
   ) {
-    // Get contract metadata & ethers contracts
+
+    // Set basic data
+    this.contractMetadataList = contractMetadataList
+    this.signerOrProvider = signerOrProvider
+    this.chainId = prizePoolMetadata.chainId
+    this.address = prizePoolMetadata.address
+
+    // Get prizePool ethers contract
     const prizePoolContract = new Contract(
       prizePoolMetadata.address,
       prizePoolMetadata.abi,
       signerOrProvider
     )
 
-    // Set data
-    this.contractMetadataList = contractMetadataList
-    this.signerOrProvider = signerOrProvider
-    this.chainId = prizePoolMetadata.chainId
-    this.address = prizePoolMetadata.address
+    // Get eip2612PermitAndDeposit metadata & ethers contracts
+    const eip2612PermitAndDeposit = getMetadataAndContract(
+      this.chainId,
+      this.signerOrProvider,
+      ContractType.EIP2612PermitAndDeposit,
+      this.contractMetadataList
+    )
 
     // Set metadata
     this.prizePoolMetadata = prizePoolMetadata
+    this.eip2612PermitAndDepositMetadata = eip2612PermitAndDeposit.contractMetadata
     this.ticketMetadata = undefined
     this.tokenMetadata = undefined
 
     // Set ethers contracts
     this.prizePoolContract = prizePoolContract
+    this.eip2612PermitAndDepositContract = eip2612PermitAndDeposit.contract
     this.ticketContract = undefined
     this.tokenContract = undefined
   }

--- a/src/PrizePool.ts
+++ b/src/PrizePool.ts
@@ -61,9 +61,9 @@ export class PrizePool {
 
     // Get prizePool ethers contract
     const prizePoolContract = new Contract(
-      prizePoolMetadata.address,
+      this.address,
       prizePoolMetadata.abi,
-      signerOrProvider
+      this.signerOrProvider
     )
 
     // Get eip2612PermitAndDeposit metadata & ethers contracts

--- a/src/PrizePool.ts
+++ b/src/PrizePool.ts
@@ -348,6 +348,7 @@ export class PrizePool {
    * @returns an ethers contract for the underlying token
    */
   async getTokenContract(options?: { eip2612?: boolean }): Promise<Contract> {
+    if (options?.eip2612) this.tokenContract = undefined
     if (this.tokenContract !== undefined) return this.tokenContract
     const getAddress = async () => {
       const result: Result = await this.prizePoolContract.functions.getToken()

--- a/src/PrizePool.ts
+++ b/src/PrizePool.ts
@@ -67,22 +67,28 @@ export class PrizePool {
     )
 
     // Get eip2612PermitAndDeposit metadata & ethers contracts
-    const eip2612PermitAndDeposit = getMetadataAndContract(
-      this.chainId,
-      this.signerOrProvider,
-      ContractType.EIP2612PermitAndDeposit,
-      this.contractMetadataList
+    const eip2612PermitAndDepositContractMetadata = this.contractMetadataList.find(
+      (contract) =>
+        contract.chainId === this.chainId && contract.type === ContractType.EIP2612PermitAndDeposit
     )
+    const eip2612PermitAndDeposit = !!eip2612PermitAndDepositContractMetadata
+      ? getMetadataAndContract(
+          this.chainId,
+          this.signerOrProvider,
+          ContractType.EIP2612PermitAndDeposit,
+          this.contractMetadataList
+        )
+      : undefined
 
     // Set metadata
     this.prizePoolMetadata = prizePoolMetadata
-    this.eip2612PermitAndDepositMetadata = eip2612PermitAndDeposit.contractMetadata
+    this.eip2612PermitAndDepositMetadata = eip2612PermitAndDeposit?.contractMetadata
     this.ticketMetadata = undefined
     this.tokenMetadata = undefined
 
     // Set ethers contracts
     this.prizePoolContract = prizePoolContract
-    this.eip2612PermitAndDepositContract = eip2612PermitAndDeposit.contract
+    this.eip2612PermitAndDepositContract = eip2612PermitAndDeposit?.contract
     this.ticketContract = undefined
     this.tokenContract = undefined
   }

--- a/src/PrizePool.ts
+++ b/src/PrizePool.ts
@@ -52,7 +52,6 @@ export class PrizePool {
     signerOrProvider: Provider | Signer,
     contractMetadataList: ContractMetadata[]
   ) {
-
     // Set basic data
     this.contractMetadataList = contractMetadataList
     this.signerOrProvider = signerOrProvider

--- a/src/User.ts
+++ b/src/User.ts
@@ -259,6 +259,7 @@ export class User extends PrizePool {
 
     const usersAddress = await this.signer.getAddress()
 
+    // NOTE: The domain's name and version are hardcoded on the ticket contract and thus should not be changed
     const domain = {
       name: 'PoolTogether ControlledToken',
       version: '1',

--- a/src/User.ts
+++ b/src/User.ts
@@ -185,10 +185,12 @@ export class User extends PrizePool {
   /**
    * Requests a signature from the user to approve a deposit
    * @param amountUnformatted an unformatted and decimal shifted amount to approve for deposits
+   * @param customDeadline a custom deadline to override the default (5 mins from signature)
    * @returns a promise to request a signature
    */
   async getPermitAndDepositSignaturePromise(
-    amountUnformatted: BigNumber
+    amountUnformatted: BigNumber,
+    customDeadline?: number
   ): Promise<(ERC2612PermitMessage & RSV) | undefined> {
     const errorPrefix = 'User [approveDepositsWithSignature]'
     await this.validateSignerNetwork(errorPrefix)
@@ -213,7 +215,7 @@ export class User extends PrizePool {
     }
 
     // NOTE: Nonce must be passed manually for signERC2612Permit to work with WalletConnect
-    const deadline = (await this.signer.provider.getBlock('latest')).timestamp + 5 * 60
+    const deadline = customDeadline ?? (await this.signer.provider.getBlock('latest')).timestamp + 5 * 60
     const response = await tokenContract.functions.nonces(usersAddress)
     const nonce: BigNumber = response[0]
 
@@ -233,10 +235,12 @@ export class User extends PrizePool {
   /**
    * Requests a signature from the user to approve a delegation
    * @param amountUnformatted an unformatted and decimal shifted amount to approve for delegation
+   * @param customDeadline a custom deadline to override the default (5 mins from signature)
    * @returns a promise to request a signature
    */
   async getPermitAndDelegateSignaturePromise(
-    amountUnformatted: BigNumber
+    amountUnformatted: BigNumber,
+    customDeadline?: number
   ): Promise<(ERC2612PermitMessage & RSV) | undefined> {
     const errorPrefix = 'User [approveDelegationWithSignature]'
     await this.validateSignerNetwork(errorPrefix)
@@ -261,7 +265,7 @@ export class User extends PrizePool {
     }
 
     // NOTE: Nonce must be passed manually for signERC2612Permit to work with WalletConnect
-    const deadline = (await this.signer.provider.getBlock('latest')).timestamp + 5 * 60
+    const deadline = customDeadline ?? (await this.signer.provider.getBlock('latest')).timestamp + 5 * 60
     const response = await ticketContract.functions.nonces(usersAddress)
     const nonce: BigNumber = response[0]
 

--- a/src/User.ts
+++ b/src/User.ts
@@ -242,7 +242,7 @@ export class User extends PrizePool {
     await this.validateSignerNetwork(errorPrefix)
 
     const ticketContract = await this.getTicketContract()
-    
+
     if (
       !this.eip2612PermitAndDepositMetadata ||
       !this.eip2612PermitAndDepositContract ||

--- a/src/User.ts
+++ b/src/User.ts
@@ -193,7 +193,7 @@ export class User extends PrizePool {
     const errorPrefix = 'User [approveDepositsWithSignature]'
     await this.validateSignerNetwork(errorPrefix)
 
-    const tokenContract = await this.getTokenContract()
+    const tokenContract = await this.getTokenContract({ eip2612: true })
 
     if (
       !this.eip2612PermitAndDepositMetadata ||
@@ -206,7 +206,7 @@ export class User extends PrizePool {
     const usersAddress = await this.signer.getAddress()
 
     const domain = {
-      name: 'PoolTogether DepositToken',
+      name: 'PoolTogether Deposit Approval',
       version: '1',
       chainId: this.chainId,
       verifyingContract: this.tokenMetadata.address
@@ -254,7 +254,7 @@ export class User extends PrizePool {
     const usersAddress = await this.signer.getAddress()
 
     const domain = {
-      name: 'PoolTogether ControlledToken',
+      name: 'PoolTogether Delegation Approval',
       version: '1',
       chainId: this.chainId,
       verifyingContract: this.ticketMetadata.address

--- a/src/User.ts
+++ b/src/User.ts
@@ -196,6 +196,7 @@ export class User extends PrizePool {
     await this.validateSignerNetwork(errorPrefix)
 
     const tokenContract = await this.getTokenContract({ eip2612: true })
+    const tokenData = await this.getTokenData()
 
     if (
       !this.eip2612PermitAndDepositMetadata ||
@@ -208,8 +209,8 @@ export class User extends PrizePool {
     const usersAddress = await this.signer.getAddress()
 
     const domain = {
-      name: 'PoolTogether Deposit Approval',
-      version: '1',
+      name: tokenData.name,
+      version: this.tokenMetadata.version.major.toString(),
       chainId: this.chainId,
       verifyingContract: this.tokenMetadata.address
     }
@@ -246,6 +247,7 @@ export class User extends PrizePool {
     await this.validateSignerNetwork(errorPrefix)
 
     const ticketContract = await this.getTicketContract()
+    const ticketData = await this.getTicketData()
 
     if (
       !this.eip2612PermitAndDepositMetadata ||
@@ -258,8 +260,8 @@ export class User extends PrizePool {
     const usersAddress = await this.signer.getAddress()
 
     const domain = {
-      name: 'PoolTogether Delegation Approval',
-      version: '1',
+      name: ticketData.name,
+      version: this.ticketMetadata.version.major.toString(),
       chainId: this.chainId,
       verifyingContract: this.ticketMetadata.address
     }

--- a/src/User.ts
+++ b/src/User.ts
@@ -307,7 +307,7 @@ export class User extends PrizePool {
 
     const formattedPermitSignature = formatEIP2612SignatureTuple(permitSignature)
     const formattedDelegateSignature = {
-      address: to || usersAddress,
+      delegate: to || usersAddress,
       signature: formatEIP2612SignatureTuple(delegateSignature)
     }
 

--- a/src/User.ts
+++ b/src/User.ts
@@ -244,7 +244,7 @@ export class User extends PrizePool {
     delegateTo?: string,
     customDeadline?: number
   ): Promise<(ERC2612TicketPermitMessage & RSV) | undefined> {
-    const errorPrefix = 'User [approveDelegationWithSignature]'
+    const errorPrefix = 'User [getPermitAndDelegateSignaturePromise]'
     await this.validateSignerNetwork(errorPrefix)
 
     const ticketContract = await this.getTicketContract()

--- a/src/User.ts
+++ b/src/User.ts
@@ -192,7 +192,7 @@ export class User extends PrizePool {
     amountUnformatted: BigNumber,
     customDeadline?: number
   ): Promise<(ERC2612PermitMessage & RSV) | undefined> {
-    const errorPrefix = 'User [approveDepositsWithSignature]'
+    const errorPrefix = 'User [getPermitAndDepositSignaturePromise]'
     await this.validateSignerNetwork(errorPrefix)
 
     const tokenContract = await this.getTokenContract({ eip2612: true })

--- a/src/User.ts
+++ b/src/User.ts
@@ -6,6 +6,7 @@ import { Overrides } from '@ethersproject/contracts'
 import { Contract as ContractMetadata } from '@pooltogether/contract-list-schema'
 import { signERC2612Permit } from 'eth-permit'
 import { RSV } from 'eth-permit/dist/rpc'
+
 import { PrizePool } from './PrizePool'
 import { ERC2612PermitMessage } from './types'
 import { validateAddress, validateSignerNetwork } from './utils'
@@ -185,16 +186,23 @@ export class User extends PrizePool {
    * @param amountUnformatted an unformatted and decimal shifted amount to approve for deposits
    * @returns a promise to request a signature
    */
-  async getPermitAndDepositSignaturePromise(amountUnformatted: BigNumber): Promise<(ERC2612PermitMessage & RSV) | undefined> {
+  async getPermitAndDepositSignaturePromise(
+    amountUnformatted: BigNumber
+  ): Promise<(ERC2612PermitMessage & RSV) | undefined> {
     const errorPrefix = 'User [approveDepositsWithSignature]'
     await this.validateSignerNetwork(errorPrefix)
 
-    const usersAddress = await this.signer.getAddress()
     const tokenContract = await this.getTokenContract()
 
-    if(!this.eip2612PermitAndDepositMetadata || !this.eip2612PermitAndDepositContract || !this.tokenMetadata || !this.signer.provider) throw new Error(
-      errorPrefix + ` | Error intitializing contract metadata.`
+    if (
+      !this.eip2612PermitAndDepositMetadata ||
+      !this.eip2612PermitAndDepositContract ||
+      !this.tokenMetadata ||
+      !this.signer.provider
     )
+      throw new Error(errorPrefix + ` | Error intitializing contract metadata.`)
+
+    const usersAddress = await this.signer.getAddress()
 
     const domain = {
       name: 'PoolTogether ControlledToken',
@@ -221,12 +229,13 @@ export class User extends PrizePool {
     return signaturePromise
   }
 
-  async depositWithSignature() {
-    // TODO
+  async getPermitAndDelegateSignaturePromise() {
+    // TODO - need a second signature (_delegateSignature) in order to deposit AND delegate through EIP2612 contract
   }
-  
+
   async depositAndDelegateWithSignature() {
-    // TODO
+    // TODO - need to check for current delegate as to not overrite it with own wallet
+    // TODO - need to call `permitAndDepositToAndDelegate` on EIP2612 contract (https://goerli.etherscan.io/address/0xaaef83B81A8Bd3b8c6C39dFaF74FED8722C5659d#writeContract)
   }
 
   //////////////////////////// Ethers read functions ////////////////////////////

--- a/src/User.ts
+++ b/src/User.ts
@@ -201,7 +201,7 @@ export class User extends PrizePool {
       !this.tokenMetadata ||
       !this.signer.provider
     )
-      throw new Error(errorPrefix + ` | Error intitializing contract metadata.`)
+      throw new Error(errorPrefix + ` | Error initializing contract metadata.`)
 
     const usersAddress = await this.signer.getAddress()
 
@@ -249,7 +249,7 @@ export class User extends PrizePool {
       !this.ticketMetadata ||
       !this.signer.provider
     )
-      throw new Error(errorPrefix + ` | Error intitializing contract metadata.`)
+      throw new Error(errorPrefix + ` | Error initializing contract metadata.`)
 
     const usersAddress = await this.signer.getAddress()
 
@@ -300,6 +300,9 @@ export class User extends PrizePool {
       await validateAddress(errorPrefix, to)
     }
 
+    if (!this.eip2612PermitAndDepositContract)
+      throw new Error(errorPrefix + ` | Error initializing contract.`)
+
     const usersAddress = await this.signer.getAddress()
 
     const formattedPermitSignature = formatEIP2612SignatureTuple(permitSignature)
@@ -309,7 +312,7 @@ export class User extends PrizePool {
     }
 
     if (Boolean(overrides)) {
-      return this.prizePoolContract.permitAndDepositToAndDelegate(
+      return this.eip2612PermitAndDepositContract.permitAndDepositToAndDelegate(
         this.address,
         amountUnformatted,
         to || usersAddress,
@@ -318,7 +321,7 @@ export class User extends PrizePool {
         overrides
       )
     } else {
-      return this.prizePoolContract.permitAndDepositToAndDelegate(
+      return this.eip2612PermitAndDepositContract.permitAndDepositToAndDelegate(
         this.address,
         amountUnformatted,
         to || usersAddress,

--- a/src/abis/ERC20AbiWithPermit.ts
+++ b/src/abis/ERC20AbiWithPermit.ts
@@ -1,0 +1,347 @@
+export default [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'spender',
+        type: 'address'
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256'
+      }
+    ],
+    name: 'Approval',
+    type: 'event'
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'from',
+        type: 'address'
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'to',
+        type: 'address'
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256'
+      }
+    ],
+    name: 'Transfer',
+    type: 'event'
+  },
+  {
+    inputs: [],
+    name: 'DOMAIN_SEPARATOR',
+    outputs: [
+      {
+        internalType: 'bytes32',
+        name: '',
+        type: 'bytes32'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
+      },
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address'
+      }
+    ],
+    name: 'allowance',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256'
+      }
+    ],
+    name: 'approve',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'account',
+        type: 'address'
+      }
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'decimals',
+    outputs: [
+      {
+        internalType: 'uint8',
+        name: '',
+        type: 'uint8'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: 'subtractedValue',
+        type: 'uint256'
+      }
+    ],
+    name: 'decreaseAllowance',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: 'addedValue',
+        type: 'uint256'
+      }
+    ],
+    name: 'increaseAllowance',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'name',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
+      }
+    ],
+    name: 'nonces',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
+      },
+      {
+        internalType: 'address',
+        name: 'spender',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: 'value',
+        type: 'uint256'
+      },
+      {
+        internalType: 'uint256',
+        name: 'deadline',
+        type: 'uint256'
+      },
+      {
+        internalType: 'uint8',
+        name: 'v',
+        type: 'uint8'
+      },
+      {
+        internalType: 'bytes32',
+        name: 'r',
+        type: 'bytes32'
+      },
+      {
+        internalType: 'bytes32',
+        name: 's',
+        type: 'bytes32'
+      }
+    ],
+    name: 'permit',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'symbol',
+    outputs: [
+      {
+        internalType: 'string',
+        name: '',
+        type: 'string'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256'
+      }
+    ],
+    name: 'transfer',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'from',
+        type: 'address'
+      },
+      {
+        internalType: 'address',
+        name: 'to',
+        type: 'address'
+      },
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256'
+      }
+    ],
+    name: 'transferFrom',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    stateMutability: 'nonpayable',
+    type: 'function'
+  }
+]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,7 +18,8 @@ export enum ContractType {
   DrawCalculatorTimelock = 'DrawCalculatorTimelock',
   PrizeDistributionBuffer = 'PrizeDistributionBuffer',
   PrizeDistributionFactory = 'PrizeDistributionFactory',
-  PrizeTierHistory = 'PrizeTierHistory'
+  PrizeTierHistory = 'PrizeTierHistory',
+  EIP2612PermitAndDeposit = 'EIP2612PermitAndDeposit'
   // ... more contract types
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,3 +60,12 @@ export interface ChildContractAddresses {
     }
   }
 }
+
+// NOTE: This is only required since the `eth-permit` package doesn't export this
+export interface ERC2612PermitMessage {
+  owner: string;
+  spender: string;
+  value: number | string;
+  nonce: number | string;
+  deadline: number | string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,9 +63,9 @@ export interface ChildContractAddresses {
 
 // NOTE: This is only required since the `eth-permit` package doesn't export this
 export interface ERC2612PermitMessage {
-  owner: string;
-  spender: string;
-  value: number | string;
-  nonce: number | string;
-  deadline: number | string;
+  owner: string
+  spender: string
+  value: number | string
+  nonce: number | string
+  deadline: number | string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,3 +69,10 @@ export interface ERC2612PermitMessage {
   nonce: number | string
   deadline: number | string
 }
+
+export interface EIP2612SignatureTuple {
+  deadline: number
+  v: number
+  r: string
+  s: string
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ export interface ChildContractAddresses {
   }
 }
 
-// NOTE: This is only required since the `eth-permit` package doesn't export this
+// NOTE: These are only required since the `eth-permit` package doesn't export all its types
 export interface ERC2612PermitMessage {
   owner: string
   spender: string
@@ -69,10 +69,23 @@ export interface ERC2612PermitMessage {
   nonce: number | string
   deadline: number | string
 }
+export interface EIP712Domain {
+  name: string
+  version: string
+  chainId: number
+  verifyingContract: string
+}
 
 export interface EIP2612SignatureTuple {
   deadline: number
   v: number
   r: string
   s: string
+}
+
+export interface ERC2612TicketPermitMessage {
+  user: string
+  delegate: string
+  nonce: number | string
+  deadline: number | string
 }

--- a/src/utils/formatEIP2612SignatureTuple.ts
+++ b/src/utils/formatEIP2612SignatureTuple.ts
@@ -1,0 +1,21 @@
+import { RSV } from 'eth-permit/dist/rpc'
+
+import { EIP2612SignatureTuple, ERC2612PermitMessage } from '../types'
+
+export const formatEIP2612SignatureTuple = (
+  rawSignature: ERC2612PermitMessage & RSV
+): EIP2612SignatureTuple => {
+
+  // NOTE: This workaround is required for hardware wallets
+  // https://ethereum.stackexchange.com/questions/103307/cannot-verifiy-a-signature-produced-by-ledger-in-solidity-using-ecrecover
+  const v = rawSignature.v < 27 ? rawSignature.v + 27 : rawSignature.v
+
+  const signatureTuple: EIP2612SignatureTuple = {
+    deadline: Number(rawSignature.deadline),
+    v: v,
+    r: rawSignature.r,
+    s: rawSignature.s
+  }
+
+  return signatureTuple
+}

--- a/src/utils/formatEIP2612SignatureTuple.ts
+++ b/src/utils/formatEIP2612SignatureTuple.ts
@@ -1,9 +1,9 @@
 import { RSV } from 'eth-permit/dist/rpc'
 
-import { EIP2612SignatureTuple, ERC2612PermitMessage } from '../types'
+import { EIP2612SignatureTuple } from '../types'
 
 export const formatEIP2612SignatureTuple = (
-  rawSignature: ERC2612PermitMessage & RSV
+  rawSignature: { deadline: string | number } & RSV
 ): EIP2612SignatureTuple => {
   // NOTE: This workaround is required for hardware wallets
   // https://ethereum.stackexchange.com/questions/103307/cannot-verifiy-a-signature-produced-by-ledger-in-solidity-using-ecrecover

--- a/src/utils/formatEIP2612SignatureTuple.ts
+++ b/src/utils/formatEIP2612SignatureTuple.ts
@@ -5,7 +5,6 @@ import { EIP2612SignatureTuple, ERC2612PermitMessage } from '../types'
 export const formatEIP2612SignatureTuple = (
   rawSignature: ERC2612PermitMessage & RSV
 ): EIP2612SignatureTuple => {
-
   // NOTE: This workaround is required for hardware wallets
   // https://ethereum.stackexchange.com/questions/103307/cannot-verifiy-a-signature-produced-by-ledger-in-solidity-using-ecrecover
   const v = rawSignature.v < 27 ? rawSignature.v + 27 : rawSignature.v

--- a/yarn.lock
+++ b/yarn.lock
@@ -3876,6 +3876,13 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eth-permit@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/eth-permit/-/eth-permit-0.2.3.tgz#7d8b051e329d2166fef32553ed397970d369cafe"
+  integrity sha512-d4tbiRQgbpdeJbdC9hdyT0SUJcJx28FIy3o2RxEAoeYI+zyYbNC0ZpdE6kxBK+7iY2payjHRE7rs7tr5EcOVLg==
+  dependencies:
+    utf8 "^3.0.0"
+
 ethers@^5.4.6:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.5.3.tgz#1e361516711c0c3244b6210e7e3ecabf0c75fca0"
@@ -8626,6 +8633,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
+  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR adds metadata and contract attributes for the newly added `EIP2612PermitAndDeposit` contracts to the `PrizePool` object and constructor.

The package `eth-permit` was added as a dependency.

When initializing a `PrizePool`, it is assumed there is either 0 or 1 `EIP2612PermitAndDeposit` contracts in the metadata list. If there is more than one, the first one listed would be used and the others ignored. If there is no contract matching these specs in the list, the prize pool's attributes of `eip2612PermitAndDepositMetadata` and `eip2612PermitAndDepositContract` will simply be undefined.

The following functions were added to `User` in order to facilitate the transactions:
- `getPermitAndDepositSignaturePromise`
- `getPermitAndDelegateSignaturePromise`
- `depositAndDelegateWithSignature`

The reason to keep the signature functions returning promises is to allow for front-end apps to implement their own loading logic and integrate easier with toasts, etc.

The `formatEIP2612SignatureTuple` helper function was added to format a `vrs` tuple from a signature, while taking into account current hardware wallet workarounds.

While most of the functions added make use of the `eth-permit` package, a custom `signERC2612TicketPermit` function had to be written in order to appropriately construct the ticket delegation permit.

The ABI for a common ERC20 with permit functionality has been added as `/abis/ERC20AbiWithPermit.ts`.